### PR TITLE
Add jwt refresh token logic and configure access token

### DIFF
--- a/src/main/java/com/blessedbits/SchoolHub/security/JWTGenerator.java
+++ b/src/main/java/com/blessedbits/SchoolHub/security/JWTGenerator.java
@@ -2,17 +2,28 @@ package com.blessedbits.SchoolHub.security;
 
 import io.jsonwebtoken.*;
 import org.springframework.security.authentication.AuthenticationCredentialsNotFoundException;
-import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Component;
 
 import java.util.Date;
 
 @Component
 public class JWTGenerator {
-    public String generateJWT(Authentication auth) {
-        String username = auth.getName();
+    public String generateAccessJWT(String username) {
         Date currentDate = new Date();
-        Date expirationDate = new Date(currentDate.getTime() + SecurityConstants.JWT_TOKEN_VALIDITY * 1000);
+        Date expirationDate = new Date(currentDate.getTime() + SecurityConstants.ACCESS_TOKEN_VALIDITY);
+
+        String token = Jwts.builder()
+                .subject(username)
+                .issuedAt(currentDate)
+                .expiration(expirationDate)
+                .signWith(SecurityConstants.SIGNING_KEY)
+                .compact();
+        return token;
+    }
+
+    public String generateRefreshJWT(String username) {
+        Date currentDate = new Date();
+        Date expirationDate = new Date(currentDate.getTime() + SecurityConstants.REFRESH_TOKEN_VALIDITY);
 
         String token = Jwts.builder()
                 .subject(username)

--- a/src/main/java/com/blessedbits/SchoolHub/security/SecurityConfig.java
+++ b/src/main/java/com/blessedbits/SchoolHub/security/SecurityConfig.java
@@ -8,6 +8,7 @@ import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -30,8 +31,7 @@ public class SecurityConfig {
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http
-                .csrf(csrf -> csrf
-                        .disable())
+                .csrf(AbstractHttpConfigurer::disable)
                 .exceptionHandling(ex -> ex
                         .authenticationEntryPoint(authEntryPoint)
                 )

--- a/src/main/java/com/blessedbits/SchoolHub/security/SecurityConstants.java
+++ b/src/main/java/com/blessedbits/SchoolHub/security/SecurityConstants.java
@@ -5,7 +5,8 @@ import io.jsonwebtoken.security.Keys;
 import java.security.Key;
 
 public class SecurityConstants {
-    public static final long JWT_TOKEN_VALIDITY = 86400;
+    public static final long ACCESS_TOKEN_VALIDITY = 600;
+    public static final long REFRESH_TOKEN_VALIDITY = 2592000;
     public static final String JWT_SECRET = "5pcGFBfkSBNpFrtgPNAl3FzpGygSwdDaLtwUQWPt";
     public static final Key SIGNING_KEY = Keys.hmacShaKeyFor(JWT_SECRET.getBytes());
 }


### PR DESCRIPTION
Added jwt generation logic for refresh token.
Configured jwt generation logic:
 Generator needs String username, instead Authentication auth.
Configured jwt validity time:
 Access token now active for 10 minutes,
 Refresh token active for 30 days.
Changed auth endpoints:
 Added jwt refresh auth endpoint ("api/auth/token/refresh"), which validates refresh token and returns new access token.
 Changed logic for login endpoint, so it now also securely inserts refresh token into cookies.