### PR TITLE
Changed cross-site lax to none

### DIFF
--- a/src/main/java/com/blessedbits/SchoolHub/controllers/AuthController.java
+++ b/src/main/java/com/blessedbits/SchoolHub/controllers/AuthController.java
@@ -85,7 +85,7 @@ public class AuthController {
                     .httpOnly(true)
                     .secure(true)
                     .path("/")
-                    .sameSite("Lax")
+                    .sameSite("None")
                     .build();
         }
         else {
@@ -93,7 +93,7 @@ public class AuthController {
                     .httpOnly(true)
                     .secure(true)
                     .path("/")
-                    .sameSite("Lax")
+                    .sameSite("None")
                     .build();
         }
 


### PR DESCRIPTION
--- Changed
Same-site origin attribute of refreshToken cookie set from lax to none, to enable frontend to receive it from backend server on different host, which means cross-site