### PR TITLE
Add auth exception response details

### DIFF
--- a/src/main/java/com/blessedbits/SchoolHub/security/JWTAuthenticationFilter.java
+++ b/src/main/java/com/blessedbits/SchoolHub/security/JWTAuthenticationFilter.java
@@ -1,16 +1,19 @@
 package com.blessedbits.SchoolHub.security;
 
+import jakarta.security.auth.message.AuthException;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.authentication.AuthenticationCredentialsNotFoundException;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
 import org.springframework.web.filter.OncePerRequestFilter;
 
+import javax.security.sasl.AuthenticationException;
 import java.io.IOException;
 
 public class JWTAuthenticationFilter extends OncePerRequestFilter {
@@ -24,7 +27,14 @@ public class JWTAuthenticationFilter extends OncePerRequestFilter {
                                     HttpServletResponse response,
                                     FilterChain filterChain) throws ServletException, IOException {
         String token = getJWTFromRequest(request);
-        if (token != null && jwtUtils.validateJWT(token)) {
+        if (token != null) {
+            try {
+                jwtUtils.validateJWT(token);
+            } catch (AuthenticationCredentialsNotFoundException e) {
+                SecurityContextHolder.clearContext();
+                request.setAttribute("exception", e.getMessage());
+                throw new AuthenticationException(e.getMessage(), e.getCause());
+            }
             String username = jwtUtils.getUsernameFromJWT(token);
 
             UserDetails userDetails = customUserDetailsService.loadUserByUsername(username);

--- a/src/main/java/com/blessedbits/SchoolHub/security/JwtAccessDeniedHandler.java
+++ b/src/main/java/com/blessedbits/SchoolHub/security/JwtAccessDeniedHandler.java
@@ -1,0 +1,21 @@
+package com.blessedbits.SchoolHub.security;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+public class JwtAccessDeniedHandler implements AccessDeniedHandler {
+
+    @Override
+    public void handle(HttpServletRequest request, HttpServletResponse response, AccessDeniedException accessDeniedException) throws IOException, ServletException {
+        response.resetBuffer();
+        response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+        response.flushBuffer();
+    }
+}

--- a/src/main/java/com/blessedbits/SchoolHub/security/JwtAuthEntryPoint.java
+++ b/src/main/java/com/blessedbits/SchoolHub/security/JwtAuthEntryPoint.java
@@ -13,6 +13,16 @@ import java.io.IOException;
 public class JwtAuthEntryPoint implements AuthenticationEntryPoint {
     @Override
     public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException, ServletException {
-        response.sendError(HttpServletResponse.SC_UNAUTHORIZED, authException.getMessage());
+        String message = (String) request.getAttribute("exception");
+        if (message == null) {
+            message = authException.getMessage();
+        }
+        String jsonResponse = String.format("{\"message\": \"%s\"}", message);
+
+        response.resetBuffer();
+        response.setContentType("application/json");
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        response.getOutputStream().print(jsonResponse);
+        response.flushBuffer();
     }
 }

--- a/src/main/java/com/blessedbits/SchoolHub/security/SecurityConfig.java
+++ b/src/main/java/com/blessedbits/SchoolHub/security/SecurityConfig.java
@@ -45,37 +45,37 @@ public class SecurityConfig {
                         .requestMatchers("/actuator/**").permitAll()
                         .requestMatchers("/auth/**").permitAll()
 
-                        .requestMatchers("/courses/**").hasAnyRole(
-                                "STUDENT", "TEACHER", "SCHOOL_ADMIN")
                         .requestMatchers("/courses/new").hasAnyRole(
                                 "TEACHER", "SCHOOL_ADMIN")
+                        .requestMatchers("/courses/**").hasAnyRole(
+                                "STUDENT", "TEACHER", "SCHOOL_ADMIN")
 
+                        .requestMatchers("/classes/new").hasRole("SCHOOL_ADMIN")
                         .requestMatchers("/classes/**").hasAnyRole(
                                 "STUDENT", "TEACHER", "SCHOOL_ADMIN")
-                        .requestMatchers("/classes/new").hasRole("SCHOOL_ADMIN")
 
                         .requestMatchers("/schools/new").hasRole("PLATFORM_ADMIN")
                         .requestMatchers("/schools/**").hasAnyRole(
                                 "USER", "STUDENT", "TEACHER", "SCHOOL_ADMIN", "PLATFORM_ADMIN")
 
+                        .requestMatchers(HttpMethod.PUT, "/users/set-duty/{id}").hasAnyRole(
+                                "SCHOOL_ADMIN", "PLATFORM_ADMIN")
                         .requestMatchers("/users/**").hasAnyRole(
                                 "USER", "STUDENT", "TEACHER", "SCHOOL_ADMIN", "PLATFORM_ADMIN")
-                        .requestMatchers(HttpMethod.PUT, "/users/set-duty/{id}").hasAnyRole(    
-                                "SCHOOL_ADMIN", "PLATFORM_ADMIN") 
-                                
+
+                        .requestMatchers("/schedules/new").hasRole("SCHOOL_ADMIN")
+                        .requestMatchers(HttpMethod.GET, "/schedules/{id}").hasAnyRole("STUDENT", "TEACHER", "SCHOOL_ADMIN")
+                        .requestMatchers(HttpMethod.PUT, "/schedules/{id}").hasRole("SCHOOL_ADMIN")
+                        .requestMatchers(HttpMethod.DELETE, "/schedules/{id}").hasRole("SCHOOL_ADMIN")
                         .requestMatchers("/schedules/**").hasAnyRole(
                                 "STUDENT", "TEACHER", "SCHOOL_ADMIN")
-                        .requestMatchers("/schedules/new").hasRole("SCHOOL_ADMIN")  
-                        .requestMatchers(HttpMethod.GET, "/schedules/{id}").hasAnyRole("STUDENT", "TEACHER", "SCHOOL_ADMIN")
-                        .requestMatchers(HttpMethod.PUT, "/schedules/{id}").hasRole("SCHOOL_ADMIN")  
-                        .requestMatchers(HttpMethod.DELETE, "/schedules/{id}").hasRole("SCHOOL_ADMIN")  
 
-                        .requestMatchers("/news/**").hasAnyRole(
-                                "STUDENT", "TEACHER", "SCHOOL_ADMIN", "PLATFORM_ADMIN")
                         .requestMatchers("/news/new").hasRole("SCHOOL_ADMIN")
                         .requestMatchers(HttpMethod.GET, "/news/{id}").hasRole("SCHOOL_ADMIN")
                         .requestMatchers(HttpMethod.PUT, "/news/{id}").hasRole("SCHOOL_ADMIN")
                         .requestMatchers(HttpMethod.DELETE, "/news/{id}").hasRole("SCHOOL_ADMIN")
+                        .requestMatchers("/news/**").hasAnyRole(
+                                "STUDENT", "TEACHER", "SCHOOL_ADMIN", "PLATFORM_ADMIN")
                 )
                 .httpBasic(Customizer.withDefaults());
         http.addFilterBefore(jwtAuthenticationFilter(), UsernamePasswordAuthenticationFilter.class);

--- a/src/main/java/com/blessedbits/SchoolHub/security/SecurityConfig.java
+++ b/src/main/java/com/blessedbits/SchoolHub/security/SecurityConfig.java
@@ -51,9 +51,9 @@ public class SecurityConfig {
                                 "STUDENT", "TEACHER", "SCHOOL_ADMIN")
                         .requestMatchers("/classes/new").hasRole("SCHOOL_ADMIN")
 
+                        .requestMatchers("/schools/new").hasRole("PLATFORM_ADMIN")
                         .requestMatchers("/schools/**").hasAnyRole(
                                 "USER", "STUDENT", "TEACHER", "SCHOOL_ADMIN", "PLATFORM_ADMIN")
-                        .requestMatchers("/schools/new").hasRole("PLATFORM_ADMIN")
 
                         .requestMatchers("/users/**").hasAnyRole(
                                 "USER", "STUDENT", "TEACHER", "SCHOOL_ADMIN", "PLATFORM_ADMIN")

--- a/src/main/java/com/blessedbits/SchoolHub/security/SecurityConfig.java
+++ b/src/main/java/com/blessedbits/SchoolHub/security/SecurityConfig.java
@@ -21,10 +21,12 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 public class SecurityConfig {
 
     private JwtAuthEntryPoint authEntryPoint;
+    private JwtAccessDeniedHandler accessDeniedHandler;
 
     @Autowired
-    public SecurityConfig(JwtAuthEntryPoint authEntryPoint) {
+    public SecurityConfig(JwtAuthEntryPoint authEntryPoint, JwtAccessDeniedHandler accessDeniedHandler) {
         this.authEntryPoint = authEntryPoint;
+        this.accessDeniedHandler = accessDeniedHandler;
     }
 
     @Bean
@@ -33,6 +35,7 @@ public class SecurityConfig {
                 .csrf(AbstractHttpConfigurer::disable)
                 .exceptionHandling(ex -> ex
                         .authenticationEntryPoint(authEntryPoint)
+                        .accessDeniedHandler(accessDeniedHandler)
                 )
                 .sessionManagement(sm -> sm
                         .sessionCreationPolicy(SessionCreationPolicy.STATELESS)


### PR DESCRIPTION
--- Added
Added JwtAccessDeniedHandler and configured it to return 503 Forbiddent in response
Added exception matcher to SecurityConfig to handle accessDenied exception in authorization phase
--- Changed
Changed JwtAuthEntryPoint to send response in 'application/json' format instead of 'text/html', connected error throws from JwtUtils validation with commence method in AuthEntryPoint
Changed order of request matchers in a way that specific ones stay before general, so authorization issue where user with student role could create courses and other related issues are fixed